### PR TITLE
Add List.getOrNull extension

### DIFF
--- a/lib/src/list_extensions.dart
+++ b/lib/src/list_extensions.dart
@@ -252,6 +252,10 @@ extension ListExtensions<E> on List<E> {
     }
     return true;
   }
+  
+  /// Returns an element at the given [index]
+  /// or `null` if the [index] is out of bounds of this list.
+  E? getOrNull(int index) => (index >= 0 && index < length) ? this[index] : null;
 }
 
 /// Various extensions on lists of comparable elements.


### PR DESCRIPTION
Add a extension function for List `getOrNull(int index)`
returns a element at the given [index] of this list, if [index] out of bounds, return `null`

Example:
```dart
final list = [1,2,3];
list.getOrNull(1); // 2
list.getOrNull(10); // null
```